### PR TITLE
Fix a logical error

### DIFF
--- a/lectures/06-conditions-loops/code/src/com/kunal/Conditionals.java
+++ b/lectures/06-conditions-loops/code/src/com/kunal/Conditionals.java
@@ -21,9 +21,9 @@ public class Conditionals {
 
         // multiple if-else
 
-//        if (salary > 10000) {
+//        if (salary > 20000) {
 //            salary += 2000; // salary = salary + 2000
-//        } else if (salary > 20000) {
+//        } else if (salary > 10000) {
 //            salary += 3000;
 //        } else {
 //            salary += 1000;


### PR DESCRIPTION
The conditions should be either in Ascending or descending order when writing `if-else-if` so no condition is skipped

initially even if `salary = 3000` the bonus added would be `2000` only instead of `3000`, because 1st condition is satisfied and program will skip the rest of `if-else-if` block.

So reverse the order of conditions